### PR TITLE
[refactor] 찜(하트) 기능 버그 수정 및 개선

### DIFF
--- a/src/js/components/_popup.js
+++ b/src/js/components/_popup.js
@@ -4,7 +4,10 @@ import { getData, getUser, putUser } from '../../../api/api'
 import { EMAIL, LOGIN_AUTH_DATA } from '../constants'
 import { initSession } from '../../pages/login/loginSession'
 // [수정] updateHeartToServer 추가
-import { updateGenrePreference, updateHeartToServer } from '../service/bookService'
+import {
+  updateGenrePreference,
+  updateHeartToServer,
+} from '../service/bookService'
 import { loadStorage } from '../utils/storage'
 
 const { isLoggedIn, currentUser } = initSession()
@@ -109,19 +112,23 @@ document.addEventListener('DOMContentLoaded', () => {
           const nowActive = btn.classList.contains('heart-active')
 
           // [추가] localStorage heart 배열도 업데이트 (6개 제한 체크에 사용)
-          const latestData = JSON.parse(localStorage.getItem(LOGIN_AUTH_DATA) || '{}')
+          const latestData = JSON.parse(
+            localStorage.getItem(LOGIN_AUTH_DATA) || '{}',
+          )
           if (nowActive) {
             latestData.heart = [...(latestData.heart || []), String(book.id)]
           } else {
-            latestData.heart = (latestData.heart || []).filter((id) => id !== String(book.id))
+            latestData.heart = (latestData.heart || []).filter(
+              (id) => id !== String(book.id),
+            )
           }
           localStorage.setItem(LOGIN_AUTH_DATA, JSON.stringify(latestData))
 
           // [추가] 서버에 찜 추가/삭제 반영
           await updateHeartToServer(book.id, nowActive)
-          
+
           if (book.tags) {
-          updateGenrePreference(book.tags, nowActive ? 1 : -1)
+            updateGenrePreference(book.tags, nowActive ? 1 : -1)
           }
         }
       }
@@ -288,22 +295,22 @@ function heartLists(heartList, bookItems) {
 // 하트 지우기
 // [수정] latestUser.heart 사용 (bookItems 불필요)
 // async function removeHeart(bookItems, bookList) {
- async function removeHeart(bookList) {
-   // 책 리스트가 없을경우 코드 종료
-   if (!bookList) return
+async function removeHeart(bookList) {
+  // 책 리스트가 없을경우 코드 종료
+  if (!bookList) return
 
-   // [추가] cloneNode로 기존 이벤트 제거 후 새로 등록 (중복 방지)
-   // getHeartList가 마이페이지를 열 때마다 호출되는데, 
-   // removeHeart 안의 addEventListener도 매번 새로 등록 됨. 
-   // 그러면 마이페이지를 3번 열면 삭제 이벤트가 3번 실행되고 서버에 요청도 3번 감.
-   // cloneNode로 기존 이벤트를 전부 제거하고 새로 등록하면 항상 1번만 실행되는 걸 보장
-   const newBookList = bookList.cloneNode(true)
-   bookList.replaceWith(newBookList)
+  // [추가] cloneNode로 기존 이벤트 제거 후 새로 등록 (중복 방지)
+  // getHeartList가 마이페이지를 열 때마다 호출되는데,
+  // removeHeart 안의 addEventListener도 매번 새로 등록 됨.
+  // 그러면 마이페이지를 3번 열면 삭제 이벤트가 3번 실행되고 서버에 요청도 3번 감.
+  // cloneNode로 기존 이벤트를 전부 제거하고 새로 등록하면 항상 1번만 실행되는 걸 보장
+  const newBookList = bookList.cloneNode(true)
+  bookList.replaceWith(newBookList)
 
-   //  const user = await getUser(EMAIL, loadEmail.email)
-   //  const updateUrl = `${VITE_API_BASE_URL}/todayPhrase/user/${user.id}`
+  //  const user = await getUser(EMAIL, loadEmail.email)
+  //  const updateUrl = `${VITE_API_BASE_URL}/todayPhrase/user/${user.id}`
 
-   newBookList.addEventListener('click', async (e) => {
+  newBookList.addEventListener('click', async (e) => {
     const target = e.target
     const deleteButton = target.closest('[data-delete="button"]')
 
@@ -338,44 +345,48 @@ function heartLists(heartList, bookItems) {
     //     heart: updateHeart.map((num) => String(num)),
     //   }
 
-      // 매번 서버에서 최신 유저 데이터 가져오기
-      const latestUser = await getUser(EMAIL, loadEmail.email)
-      const latestUpdateUrl = `${VITE_API_BASE_URL}/todayPhrase/user/${latestUser.id}`
-    
-      // 최신 heart 배열 기준으로 필터링
-      const updateHeart = latestUser.heart.filter((id) => id !== String(deleteBookValue))
-    
-      const updateData = {
-        ...latestUser,
-        heart: updateHeart,
+    // 매번 서버에서 최신 유저 데이터 가져오기
+    const latestUser = await getUser(EMAIL, loadEmail.email)
+    const latestUpdateUrl = `${VITE_API_BASE_URL}/todayPhrase/user/${latestUser.id}`
+
+    // 최신 heart 배열 기준으로 필터링
+    const updateHeart = latestUser.heart.filter(
+      (id) => id !== String(deleteBookValue),
+    )
+
+    const updateData = {
+      ...latestUser,
+      heart: updateHeart,
+    }
+
+    try {
+      // 바뀐 데이터 PUT
+      // await putUser(updateUrl, updateData)
+      await putUser(latestUpdateUrl, updateData)
+
+      // [추가] localStorage heart 배열도 업데이트 (6개 제한 체크에 사용)
+      const savedData = JSON.parse(
+        localStorage.getItem(LOGIN_AUTH_DATA) || '{}',
+      )
+      savedData.heart = updateHeart
+      localStorage.setItem(LOGIN_AUTH_DATA, JSON.stringify(savedData))
+
+      // [추가] 화면에서도 제거 (기존 removeHeart에는 없었음)
+      const targetLi = deleteButton.closest('li')
+      if (targetLi) {
+        targetLi.style.opacity = '0'
+        targetLi.style.transition = '0.3s'
+        setTimeout(() => {
+          targetLi.remove()
+          checkEmptyList()
+        }, 300)
       }
-
-      try {
-        // 바뀐 데이터 PUT
-        // await putUser(updateUrl, updateData)
-        await putUser(latestUpdateUrl, updateData)
-
-        // [추가] localStorage heart 배열도 업데이트 (6개 제한 체크에 사용)
-        const savedData = JSON.parse(localStorage.getItem(LOGIN_AUTH_DATA) || '{}')
-        savedData.heart = updateHeart
-        localStorage.setItem(LOGIN_AUTH_DATA, JSON.stringify(savedData))
-
-        // [추가] 화면에서도 제거 (기존 removeHeart에는 없었음)
-        const targetLi = deleteButton.closest('li')
-        if (targetLi) {
-          targetLi.style.opacity = '0'
-          targetLi.style.transition = '0.3s'
-          setTimeout(() => {
-            targetLi.remove()
-            checkEmptyList()
-          }, 300)
-        }
-      } catch (error) {
-        console.error('삭제 중 오류발생', error)
-        alert('좋아요 삭제에 실패했습니다. 다시 시도해주세요.')
-      }
-    })
-  }
+    } catch (error) {
+      console.error('삭제 중 오류발생', error)
+      alert('좋아요 삭제에 실패했습니다. 다시 시도해주세요.')
+    }
+  })
+}
 
 // 마이페이지 내부 userId 변경하는 함수
 function updateUserDiSplay() {


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

찜(하트) 기능 버그 수정 및 개선
1. updateHeartToServer import 추가 및 서버 반영
 - 찜 버튼 클릭 시 화면만 바뀌고 서버에 저장이 안 되던 문제 수정
 2. 6개 제한 체크 방식 수정
 - li 개수로 체크하면 항상 0이 반환되는 문제가 있어서 localStorage의 heart 배열 길이로 변경
3. localStorage 업데이트 순서 변경
 - 서버 응답 전에 localStorage를 먼저 업데이트해서 마이페이지 즉시 반영
4. getHeartList 서버 → localStorage 기반으로 변경
 - 서버 응답 지연으로 마이페이지에 바로 반영 안 되던 문제 수정
5. getData 방식 변경
 - id마다 개별 API 호출 → 전체 데이터 한 번에 가져온 후 find로 매칭해서 API 호출 횟수 감소
6. cloneNode로 삭제 이벤트 중복 방지
 - 마이페이지를 열 때마다 이벤트가 중복 등록되어 삭제 요청이 여러 번 가던 문제 수정
7. 삭제 버튼 null 체크 수정
 - closest('[data-id]')가 null을 반환할 수 있어서 deleteButton.dataset.id로 직접 접근하도록 변경
8. 마이페이지 삭제 시 서버 + 화면 + localStorage 동시 반영
 - 기존에는 서버에만 삭제되고 화면 제거와 localStorage 업데이트가 없었음. 또한 연속 삭제 시 데이터가 꼬이는 문제를 매번 서버에서 최신 데이터를 가져와 필터링하도록 수정
9. 중복 이벤트 주석 처리
 - DOMContentLoaded 안 삭제 이벤트와 setTimeout 블록이 중복되어 주석 처리


하늬님 제가 찜 삭제 버튼 코드에 성형 수술을 한거 같아서 한번 확인 부탁드립니다..
하다보니 너무 뒤엎은거같아요..ㅠㅠ

## 이슈

resolves #103 
